### PR TITLE
Add cd workflow for plugin releasing

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,17 @@
+name: CD
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  cd:
+    uses: halo-sigs/reusable-workflows/.github/workflows/plugin-cd.yaml@v3
+    secrets:
+      halo-pat: ${{ secrets.HALO_PAT }}
+    permissions:
+      contents: write
+    with:
+      app-id: app-UUaHP
+      ui-path: "ui"


### PR DESCRIPTION
添加 cd.yaml，用于在创建 Release 之后同步在 Halo 应用市场发布版本。

合并此 PR 之后需要在 https://github.com/acanyo/halo-plugin-zenNavigator/settings/secrets/actions 创建一个名为 `HALO_PAT` 的 Secret，PAT 需要去 https://www.halo.run/uc/profile?tab=pat 创建，勾选 `应用市场开发者 -> 版本管理` 的权限。